### PR TITLE
Use DataFrames.jl in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,105 @@
 Utilities to scrape [BoardGameGeek.com](https://boardgamegeek.com), the IMDB of board games.
 
 ## Installation
-To install this package and its dependencies, open the Julia REPL and run 
+To install this package, open the Julia package manager by typing `]` in the REPL and run 
 ```julia-repl
-julia> ]add https://github.com/adrhill/BoardGameGeek.jl
+pkg> add BoardGameGeek
 ```
-The package is compatible with all Julia versions starting at `1.0`.
+BoardGameGeek.jl is compatible with all Julia versions ⩾ `1.0`.
 
-## Example
-```julia-repl
-julia> userreviews("bggjulia")
-4-element Vector{BoardGameGeek.BGGReview}:
- 9.0/10 for Arboretum from bggjulia
- 8.5/10 for Decrypto from bggjulia
- 10.0/10 for Go from bggjulia
- 9.0/10 for Pax Pamir: Second Edition from bggjulia
+## Quick tour
+Start by importing this package and [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl):
+```julia
+using BoardGameGeek
+using DataFrames
 ```
 
-## Quick reference
+We can query the reviews a specific user wrote via `userreviews(username)`
+```julia
+julia> user = "bggjulia"
+
+julia> DataFrame(userreviews(user))
+4×5 DataFrame
+ Row │ id      name                       username  rating   comment 
+     │ Int64   String                     String    Float32  String  
+─────┼───────────────────────────────────────────────────────────────
+   1 │ 140934  Arboretum                  bggjulia      9.0
+   2 │ 225694  Decrypto                   bggjulia      8.5
+   3 │    188  Go                         bggjulia     10.0
+   4 │ 256960  Pax Pamir: Second Edition  bggjulia      9.0
+```
+
+or simply use `collection` get the game IDs of his collection
+```julia
+julia> collection(user)
+4-element Vector{Int64}:
+ 140934
+ 225694
+    188
+ 256960
+```
+
+### Game reviews
+Use `gamereviews(id)` to scrape all reviews that were written for a specific game
+```julia
+julia> DataFrame(gamereviews(188))
+Scraping 15700 reviews for Go... 100%|█████████████████████| Time: 0:06:31
+15700×5 DataFrame
+   Row │ id     name    username          rating   comment                       ⋯
+       │ Int64  String  String            Float32  String                        ⋯
+───────┼──────────────────────────────────────────────────────────────────────────
+     1 │   188  Go      xenocles             10.0  My all time favourite 'classi ⋯
+     2 │   188  Go      guus                 10.0  The mother of all strategy ga
+     3 │   188  Go      Varthlokkur          10.0
+     4 │   188  Go      Hiroshi Ishikawa     10.0  Simple rule yet extremely dee
+     5 │   188  Go      layotte              10.0                                ⋯
+   ⋮   │   ⋮      ⋮            ⋮             ⋮                     ⋮             ⋱
+ 15696 │   188  Go      aircastle             1.0
+ 15697 │   188  Go      ashleybobal53         1.0
+ 15698 │   188  Go      danperrault           1.0
+ 15699 │   188  Go      vikings40             1.0                                ⋯
+ 15700 │   188  Go      akaiready             1.0
+                                                   1 column and 15690 rows omitted
+```
+Note that this can take a while for games with many reviews, as we don't want to run into the BoardGameGeek API rate limit. 
+The default wait time of 2 seconds per 100 reviews can be changed via the keyword argument `waittime`.
+
+
+
+### Full game info
+Use `gameinfo(id)` to obtain all sorts of information about a game. 
+Refer to the reference below for a summary of all data.
+```julia
+julia> DataFrame(gameinfo(collection(user)))
+4×24 DataFrame
+ Row │ id      name                       yearpublished  minplayers  maxplayers  ⋯
+     │ Int64   String                     Int64          Int64       Int64       ⋯
+─────┼────────────────────────────────────────────────────────────────────────────
+   1 │ 140934  Arboretum                           2015           2           4  ⋯
+   2 │ 225694  Decrypto                            2018           3           8
+   3 │    188  Go                                 -2200           2           2
+   4 │ 256960  Pax Pamir: Second Edition           2019           1           5
+                                                                19 columns omitted
+```
+
+### GeekBuddies
+Finally, we can also take a look at "GeekBuddies" and user profiles via `userinfo(name)`: 
+```julia
+julia> buddies(user)
+2-element Vector{String}:
+ "Aldie"
+ "dakarp"
+
+julia> DataFrame(userinfo(buddies(user)))
+2×5 DataFrame
+ Row │ id     name    country        yearregistered  lastlogin  
+     │ Int64  String  String         Int64           Date       
+─────┼──────────────────────────────────────────────────────────
+   1 │   688  Aldie   United States            1999  2022-02-13
+   2 │   792  dakarp  United States            2002  2022-02-13
+```
+
+## Reference
 ### Exported functions
 |                       | Description                                       |
 |:----------------------|:--------------------------------------------------|
@@ -32,33 +114,13 @@ julia> userreviews("bggjulia")
 | `userreviews(name)`   | return all reviews written by a user              |
 | `userinfo(name)`      | return basic user information                     |
 | `buddies(name)`       | return usernames of a user's friends              |
-
+| `collection(name)`    | return game IDs of a user's collection            | 
 
 ### Data types
-`BGGReview`
-```
-id       :: Int64
-name     :: String
-username :: String
-rating   :: Float32
-comment  :: String
-```
-
-`BGGUser`
-```
-id             :: Int64
-name           :: String
-country        :: String
-yearregistered :: Int64
-lastlogin      :: Date
-```
-
-`BGGGameInfo`
+Fields of a `BGGGameInfo` object returned by `gameinfo(id)`:
 ```
 id                   :: Int64
 name                 :: String
-mechanics            :: Vector{String}
-families             :: Vector{String}
 yearpublished        :: Int64
 minplayers           :: Int64
 maxplayers           :: Int64
@@ -66,7 +128,6 @@ playingtime          :: Int64
 minplaytime          :: Int64
 maxplaytime          :: Int64
 minage               :: Int64
-suggested_numplayers :: Dict{String, Tuple{Int64, Int64, Int64}}
 usersrated           :: Int64
 average              :: Float32
 bayesaverage         :: Float32
@@ -79,6 +140,9 @@ wishing              :: Int64
 numcomments          :: Int64
 numweights           :: Int64
 averageweight        :: Float32
+mechanics            :: Vector{String}
+families             :: Vector{String}
+suggested_numplayers :: Dict{String, Tuple{Int64, Int64, Int64}}
 ```
 
 [docs-stab-img]: https://img.shields.io/badge/docs-stable-blue.svg

--- a/src/BoardGameGeek.jl
+++ b/src/BoardGameGeek.jl
@@ -16,7 +16,7 @@ include("game.jl")
 include("user.jl")
 
 export BGGUser
-export userinfo, userreviews, buddies
+export userinfo, userreviews, buddies, collection
 export gameinfo, gamereviews
 
 end # module

--- a/src/user.jl
+++ b/src/user.jl
@@ -8,44 +8,72 @@ end
 
 """
     userinfo(name::String)
+    userinfo(names::AbstractArray{<:String})
 
 Get user from name string.
 """
-function userinfo(name::AbstractString)
+function userinfo(name::AbstractString; waittime=0.0f0)
     doc = get_xml("$XMLAPI2/user?name=$(name)")
     id = parse(Int, findfirst("/user", doc)["id"])
     name = findfirst("/user", doc)["name"]
     yearregistered = parse(Int, findfirst("/user/yearregistered", doc)["value"])
     lastlogin = Date(findfirst("/user/lastlogin", doc)["value"])
     country = findfirst("/user/country", doc)["value"]
+
+    sleep(waittime)
     return BGGUser(id, name, country, yearregistered, lastlogin)
+end
+
+function userinfo(names::AbstractArray{<:String}; waittime=2.0f0) # add waittime by default
+    usercount = length(names)
+    users = Vector{BGGUser}(undef, usercount) # pre-allocate
+    @showprogress 1 "Scraping $usercount user profiles..." for (i, n) in enumerate(names)
+        users[i] = userinfo(n; waittime=waittime)
+    end
+    return users
 end
 
 """
     buddies(name::String)
+    buddies(names::AbstractArray{<:String})
     buddies(user::BGGUser)
 
 Return list of user names of buddies of a user.
 """
-function buddies(name::String)
+function buddies(name::String; waittime=0.0f0)
     doc = get_xml("$XMLAPI2/user?name=$(name)&buddies=1")
+
+    sleep(waittime)
     return [b["name"] for b in findall("/user/buddies/buddy", doc)]
 end
+
+function buddies(names::AbstractArray{<:String}; waittime=2.0f0) # add waittime by default
+    return [buddies(n; waittime=waittime) for n in names]
+end
+
 buddies(user::BGGUser) = buddies(user.name)
 
 """
     userreviews(name::String)
+    userreviews(names::AbstractArray{<:String})
     userreviews(user::BGGUser)
 
 Return list of all board game reviews a user wrote (ignoring expansions).
 """
-function userreviews(name::String)
+function userreviews(name::String; waittime=0.0f0)
     doc = get_xml(
         "$(XMLAPI2)/collection?username=$(name)&rated=1&stats=1&excludesubtype=boardgameexpansion",
     )
     games = findall("/items/item", doc)
+
+    sleep(waittime)
     return _parse_review_from_collection.(games, name)
 end
+
+function userreviews(names::AbstractArray{<:String}; waittime=2.0f0) # add waittime by default
+    return collect(Iterators.flatten(userreviews(n; waittime=waittime) for n in names))
+end
+
 userreviews(user::BGGUser) = userreviews(user.name)
 
 function _parse_review_from_collection(n::EzXML.Node, username)
@@ -60,3 +88,12 @@ function _parse_review_from_collection(n::EzXML.Node, username)
     end
     return BGGReview(id, gamename, username, rating, comment)
 end
+
+"""
+    collection(name::String)
+    collection(user::BGGUser)
+
+Return game ids in collection of user.
+"""
+collection(name::String) = getproperty.(userreviews(name), :id)
+collection(user::BGGUser) = collection(user.name)

--- a/test/test_game.jl
+++ b/test/test_game.jl
@@ -12,3 +12,6 @@ reviews = gamereviews(id)
 
 reviews2 = gamereviews(id; waittime=2.5, pagesize=50)
 @test reviews2 == reviews
+
+games = gameinfo([id])
+@test first(games).name == game.name

--- a/test/test_user.jl
+++ b/test/test_user.jl
@@ -27,4 +27,4 @@ vbuds = buddies([name])
 vreviews = userreviews([name])
 @test first(vuser) == user
 @test first(vbuds) == buds
-@test first(vreviews) == reviews
+@test vreviews == reviews

--- a/test/test_user.jl
+++ b/test/test_user.jl
@@ -9,6 +9,9 @@ user = userinfo(name)
 @test user.country == "Poland"
 @test user.yearregistered == 2022
 
+buds = buddies(name)
+@test length(buds) == 2
+
 reviews = userreviews(name)
 @test length(reviews) == 4
 
@@ -18,3 +21,10 @@ r = first(sort(reviews; by=r -> -r.rating))
 @test r.username == "bggjulia"
 @test r.rating == 10.0
 @test r.comment == ""
+
+vuser = userinfo([name])
+vbuds = buddies([name])
+vreviews = userreviews([name])
+@test first(vuser) == user
+@test first(vbuds) == buds
+@test first(vreviews) == reviews


### PR DESCRIPTION
Closes #1 

DataFrames works out of the box with BoardGameGeek.jl's datatypes, to no dependency was added. Instead I just updated the readme.

Other changes:
* added vectorized functions with delays and progress bars – as to not run into the BGG API rate limit 
* for convenience, the function `collection` was added, which returns game IDs of a user's collection.